### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ We checked under the following versions.
 Download or clone the latest version sources, and build with CMake.
 
 ```
-git clone 
-https://github.com/hmdlab/RaptRanker.git
+git clone https://github.com/hmdlab/RaptRanker.git
 cd RaptRanker
 mkdir build
 cd build


### PR DESCRIPTION
The installation example was not valid because there was a line break within `git clone`.
Removed line break to enable correct installation.